### PR TITLE
test: cover api client and retrofit

### DIFF
--- a/DevOps/app/build.gradle.kts
+++ b/DevOps/app/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.11.0")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+    testImplementation("org.robolectric:robolectric:4.10.3")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 }
@@ -50,8 +51,8 @@ jacoco {
 }
 
 tasks.withType<Test> {
-    useJUnitPlatform()
     finalizedBy("jacocoTestReport")
+    finalizedBy(rootProject.tasks.named("sonarqube"))
 }
 
 tasks.register<JacocoReport>("jacocoTestReport") {

--- a/DevOps/app/src/test/java/com/example/devops/ApiServiceTest.kt
+++ b/DevOps/app/src/test/java/com/example/devops/ApiServiceTest.kt
@@ -11,7 +11,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 class ApiServiceTest {
     @Test
-    fun `updateScore sends POST and returns 200`() {
+    fun `updateScore sends POST with body`() {
         val server = MockWebServer()
         server.enqueue(MockResponse().setResponseCode(200))
         server.start()
@@ -28,9 +28,35 @@ class ApiServiceTest {
             val request = server.takeRequest()
             assertEquals("/api/user/addscore", request.path)
             assertEquals("POST", request.method)
+            assertEquals("{\"id\":1,\"name\":\"Ann\",\"score\":5}", request.body.readUtf8())
             assertEquals(200, response.code())
         }
 
         server.shutdown()
+    }
+
+    @Test
+    fun `getAllUsers sends GET and parses users`() {
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setBody("""[{"id":1,"name":"Ann","score":5}]"""))
+        server.start()
+
+        val retrofit = Retrofit.Builder()
+            .baseUrl(server.url("/"))
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+
+        val service = retrofit.create(ApiService::class.java)
+        val response = service.getAllUsers().execute()
+        val request = server.takeRequest()
+        server.shutdown()
+
+        assertEquals("/api/user/getusers", request.path)
+        assertEquals("GET", request.method)
+        val users = response.body()
+        assertNotNull(users)
+        assertEquals(1, users!!.size)
+        assertEquals("Ann", users[0].name)
+        assertEquals(5, users[0].score)
     }
 }

--- a/DevOps/app/src/test/java/com/example/devops/MainActivityTest.kt
+++ b/DevOps/app/src/test/java/com/example/devops/MainActivityTest.kt
@@ -1,0 +1,37 @@
+package com.example.devops
+
+import android.os.Looper
+import android.widget.TableRow
+import android.widget.TextView
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+
+@RunWith(RobolectricTestRunner::class)
+class MainActivityTest {
+
+    @Test
+    fun `onCreate loads webView with url`() {
+        val activity = Robolectric.buildActivity(MainActivity::class.java).setup().get()
+        assertNotNull(activity.webView)
+        assertEquals("file:///android_asset/index.html", activity.webView.url)
+    }
+
+    @Test
+    fun `fillTable adds rows for users`() {
+        val activity = Robolectric.buildActivity(MainActivity::class.java).setup().get()
+        val users = listOf(User(1, "Alice", 5), User(2, "Bob", 7))
+        activity.fillTable(users)
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+        assertEquals(users.size, activity.tableLayout.childCount)
+        val firstRow = activity.tableLayout.getChildAt(0) as TableRow
+        val nameTv = firstRow.getChildAt(0) as TextView
+        val scoreTv = firstRow.getChildAt(1) as TextView
+        assertEquals("Alice", nameTv.text)
+        assertEquals("5", scoreTv.text.toString())
+    }
+}

--- a/DevOps/build.gradle.kts
+++ b/DevOps/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-
     id("com.android.application") version "8.2.2" apply false
     id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+    id("org.sonarqube") version "4.4.1.3373"
 }

--- a/DevOps/sonar-project.properties
+++ b/DevOps/sonar-project.properties
@@ -1,0 +1,7 @@
+sonar.projectKey=DevOps
+sonar.projectName=DevOps
+sonar.host.url=http://localhost:9000
+sonar.sources=app/src/main/java
+sonar.tests=app/src/test/java
+sonar.kotlin.coveragePlugin=jacoco
+sonar.coverage.jacoco.xmlReportPaths=app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml


### PR DESCRIPTION
## Summary
- add MainActivity Robolectric tests covering web view loading and table rendering
- include Robolectric in unit test dependencies and drop JUnit Platform to run Android tests
- centralize SonarQube config in `sonar-project.properties`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7caca22c483248b3a0b8ac6962b49